### PR TITLE
Remove global from token naming schema

### DIFF
--- a/tokens.json
+++ b/tokens.json
@@ -1,88 +1,86 @@
 {
-  "global": {
-    "color": {
-      "base": {
-        "yellow": {
-          "50": {
-            "value": "#FFF069",
-            "type": "color"
-          },
-          "100": {
-            "value": "#F4D24B",
-            "type": "color"
-          },
-          "200": {
-            "value": "#D6B42D",
-            "type": "color"
-          }
+  "color": {
+    "base": {
+      "yellow": {
+        "50": {
+          "value": "#FFF069",
+          "type": "color"
         },
-        "blue": {
-          "50": {
-            "value": "#A7E2FF",
-            "type": "color"
-          },
-          "100": {
-            "value": "#89C4FA",
-            "type": "color"
-          },
-          "200": {
-            "value": "#6BA6DC",
-            "type": "color"
-          }
+        "100": {
+          "value": "#F4D24B",
+          "type": "color"
         },
-        "red": {
-          "50": {
-            "value": "#FFA7A7",
-            "type": "color"
-          },
-          "100": {
-            "value": "#FA8989",
-            "type": "color"
-          },
-          "200": {
-            "value": "#DC6B6B",
-            "type": "color"
-          }
+        "200": {
+          "value": "#D6B42D",
+          "type": "color"
+        }
+      },
+      "blue": {
+        "50": {
+          "value": "#A7E2FF",
+          "type": "color"
         },
-        "green": {
-          "50": {
-            "value": "#8AAFBA",
-            "type": "color"
-          },
-          "100": {
-            "value": "#6C919C",
-            "type": "color"
-          },
-          "200": {
-            "value": "#4E737E",
-            "type": "color"
-          }
+        "100": {
+          "value": "#89C4FA",
+          "type": "color"
         },
-        "purple": {
-          "50": {
-            "value": "#F0D0FF",
-            "type": "color"
-          },
-          "100": {
-            "value": "#D2B2F8",
-            "type": "color"
-          },
-          "200": {
-            "value": "#B494DA",
-            "type": "color"
-          }
+        "200": {
+          "value": "#6BA6DC",
+          "type": "color"
+        }
+      },
+      "red": {
+        "50": {
+          "value": "#FFA7A7",
+          "type": "color"
         },
-        "gray": {
-          "50": {
-            "value": "#121212",
-            "type": "color"
-          }
+        "100": {
+          "value": "#FA8989",
+          "type": "color"
         },
-        "white": {
-          "50": {
-            "value": "#FFFFFF",
-            "type": "color"
-          }
+        "200": {
+          "value": "#DC6B6B",
+          "type": "color"
+        }
+      },
+      "green": {
+        "50": {
+          "value": "#8AAFBA",
+          "type": "color"
+        },
+        "100": {
+          "value": "#6C919C",
+          "type": "color"
+        },
+        "200": {
+          "value": "#4E737E",
+          "type": "color"
+        }
+      },
+      "purple": {
+        "50": {
+          "value": "#F0D0FF",
+          "type": "color"
+        },
+        "100": {
+          "value": "#D2B2F8",
+          "type": "color"
+        },
+        "200": {
+          "value": "#B494DA",
+          "type": "color"
+        }
+      },
+      "gray": {
+        "50": {
+          "value": "#121212",
+          "type": "color"
+        }
+      },
+      "white": {
+        "50": {
+          "value": "#FFFFFF",
+          "type": "color"
         }
       }
     }
@@ -90,7 +88,7 @@
   "$themes": [],
   "$metadata": {
     "tokenSetOrder": [
-      "global"
+      "color"
     ]
   }
 }


### PR DESCRIPTION
Instead of having a css custom variable with the value `global-color-base-yellow-50` which is a mouthful, simplify to `color-base-yellow-50`. 